### PR TITLE
Implement git fallback for 403 errors in New-GitHubRef function

### DIFF
--- a/tests/e2e/SemVerValidation.Tests.ps1
+++ b/tests/e2e/SemVerValidation.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
     # Disable API retries for faster test execution
     # Individual tests that need to verify retry behavior will override this
     $env:GITHUB_API_DISABLE_RETRY = 'true'
+    $env:GITHUB_API_ALLOW_GIT_FALLBACK = 'true'
     
     # Create a temporary git repository for testing
     $script:testRepoPath = Join-Path $TestDrive "test-repo"
@@ -218,6 +219,7 @@ AfterAll {
     Set-Location $script:originalLocation
     # Clean up environment variables
     Remove-Item Env:GITHUB_API_DISABLE_RETRY -ErrorAction SilentlyContinue
+    Remove-Item Env:GITHUB_API_ALLOW_GIT_FALLBACK -ErrorAction SilentlyContinue
     Remove-Item Env:GITHUB_REPOSITORY -ErrorAction SilentlyContinue
 }
 

--- a/tests/integration/SemVerChecker.Tests.ps1
+++ b/tests/integration/SemVerChecker.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     
     # Disable API retries for faster test execution
     $env:GITHUB_API_DISABLE_RETRY = 'true'
+    $env:GITHUB_API_ALLOW_GIT_FALLBACK = 'true'
     
     # Create a temporary git repository for testing
     $script:testRepoPath = Join-Path $TestDrive "test-repo"
@@ -217,6 +218,7 @@ AfterAll {
     Set-Location $script:originalLocation
     # Clean up environment variables
     Remove-Item Env:GITHUB_API_DISABLE_RETRY -ErrorAction SilentlyContinue
+    Remove-Item Env:GITHUB_API_ALLOW_GIT_FALLBACK -ErrorAction SilentlyContinue
     Remove-Item Env:GITHUB_REPOSITORY -ErrorAction SilentlyContinue
 }
 


### PR DESCRIPTION
Introduce a fallback mechanism in the New-GitHubRef function to handle 403 errors more gracefully. This enhancement improves error handling when interacting with GitHub.